### PR TITLE
fix memory leak problem in ios

### DIFF
--- a/ios/AMap3D/maps/AMapMarker.m
+++ b/ios/AMap3D/maps/AMapMarker.m
@@ -9,7 +9,7 @@
     MAAnnotationView *_annotationView;
     MACustomCalloutView *_calloutView;
     UIView *_customView;
-    AMapView *_mapView;
+    __weak AMapView *_mapView;
     MAPinAnnotationColor _pinColor;
     UIImage *_image;
     CGPoint _centerOffset;


### PR DESCRIPTION
因为marker引用了mapview导致循环引用了。fix by ofo_chengyong