### PR TITLE
修复 ios 动画过程中创建的 MapView 宽高可能超出的问题

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 # The target name is most likely the name of your project.
 target 'RNAMap3D' do
@@ -18,7 +18,7 @@ target 'RNAMap3D' do
 
   # Third party deps podspec link
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'GLog', :podspec => '../node_modules/react-native/third-party-podspecs/GLog.podspec'
+  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   pod 'react-native-amap3d', path: '../lib/ios/'

--- a/ios/RNAMap3D.xcodeproj/project.pbxproj
+++ b/ios/RNAMap3D.xcodeproj/project.pbxproj
@@ -601,7 +601,6 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				2E4AB8B2C8225BFA5C5BEB1C /* [CP] Embed Pods Frameworks */,
 				5D655E586AD9A3C52B97F6AD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -1040,21 +1039,6 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		2E4AB8B2C8225BFA5C5BEB1C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RNAMap3D/Pods-RNAMap3D-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		5D655E586AD9A3C52B97F6AD /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1062,11 +1046,13 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-RNAMap3D/Pods-RNAMap3D-resources.sh",
-				"${PODS_ROOT}/AMap3DMap/MAMapKit.framework/AMap.bundle",
+				"${PODS_ROOT}/AMap3DMap-NO-IDFA/MAMapKit.framework/AMap.bundle",
+				"${PODS_ROOT}/AMapNavi-NO-IDFA/AMapNaviKit.framework/AMapNavi.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AMap.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AMapNavi.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/ios/AMap3D/maps/AMapMarker.m
+++ b/lib/ios/AMap3D/maps/AMapMarker.m
@@ -78,9 +78,9 @@
     _active = active;
     dispatch_async(dispatch_get_main_queue(), ^{
         if (active) {
-            [_mapView selectAnnotation:_annotation animated:YES];
+            [_mapView.mapView selectAnnotation:_annotation animated:YES];
         } else {
-            [_mapView deselectAnnotation:_annotation animated:YES];
+            [_mapView.mapView deselectAnnotation:_annotation animated:YES];
         }
     });
 }
@@ -109,7 +109,7 @@
 }
 
 - (void)_handleTap:(UITapGestureRecognizer *)recognizer {
-    [_mapView selectAnnotation:_annotation animated:YES];
+    [_mapView.mapView selectAnnotation:_annotation animated:YES];
 }
 
 - (MAAnnotationView *)annotationView {

--- a/lib/ios/AMap3D/maps/AMapView.h
+++ b/lib/ios/AMap3D/maps/AMapView.h
@@ -2,7 +2,9 @@
 
 @class AMapMarker;
 
-@interface AMapView : MAMapView
+@interface AMapView : UIView <MAMapViewDelegate>
+
+@property(nonatomic) MAMapView *mapView;
 
 @property(nonatomic, copy) RCTBubblingEventBlock onLocation;
 @property(nonatomic, copy) RCTBubblingEventBlock onPress;

--- a/lib/ios/AMap3D/maps/AMapView.m
+++ b/lib/ios/AMap3D/maps/AMapView.m
@@ -14,35 +14,43 @@
 - (instancetype)init {
     _markers = [NSMutableDictionary new];
     self = [super init];
+    
+    MAMapView *mapView = [MAMapView new];
+    self.mapView = mapView;
+    mapView.centerCoordinate = CLLocationCoordinate2DMake(39.9242, 116.3979);
+    mapView.zoomLevel = 10;
+    mapView.delegate = self;
+    [self addSubview:mapView];
+    
     return self;
 }
 
 - (void)setShowsTraffic:(BOOL)shows {
-    self.showTraffic = shows;
+    self.mapView.showTraffic = shows;
 }
 
 - (void)setTiltEnabled:(BOOL)enabled {
-    self.rotateCameraEnabled = enabled;
+    self.mapView.rotateCameraEnabled = enabled;
 }
 
 - (void)setLocationEnabled:(BOOL)enabled {
-    self.showsUserLocation = enabled;
+    self.mapView.showsUserLocation = enabled;
 }
 
 - (void)setShowCompass:(BOOL)enabled {
-    self.showsCompass = enabled;
+    self.mapView.showsCompass = enabled;
 }
 
 - (void)setCoordinate:(CLLocationCoordinate2D)coordinate {
-    self.centerCoordinate = coordinate;
+    self.mapView.centerCoordinate = coordinate;
 }
 
 - (void)setTilt:(CGFloat)degree {
-    self.cameraDegree = degree;
+    self.mapView.cameraDegree = degree;
 }
 
 - (void)setRotation:(CGFloat)degree {
-    self.rotationDegree = degree;
+    self.mapView.rotationDegree = degree;
 }
 
 - (void)setLocationStyle:(LocationStyle *)locationStyle {
@@ -53,13 +61,13 @@
     _locationStyle.strokeColor = locationStyle.strokeColor;
     _locationStyle.lineWidth = locationStyle.strokeWidth;
     _locationStyle.image = locationStyle.image;
-    [self updateUserLocationRepresentation:_locationStyle];
+    [self.mapView updateUserLocationRepresentation:_locationStyle];
 }
 
 // 如果在地图未加载的时候调用改方法，需要先将 region 存起来，等地图加载完成再设置
 - (void)setRegion:(MACoordinateRegion)region {
     if (self.loaded) {
-        super.region = region;
+        self.mapView.region = region;
     } else {
         self.initialRegion = region;
     }
@@ -71,27 +79,197 @@
         marker.mapView = self;
         _markers[[@(marker.annotation.hash) stringValue]] = marker;
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self addAnnotation:marker.annotation];
+            [self.mapView addAnnotation:marker.annotation];
         });
     }
     if ([subview isKindOfClass:[AMapOverlay class]]) {
-        [self addOverlay:(id <MAOverlay>) subview];
+        [self.mapView addOverlay:(id <MAOverlay>) subview];
     }
 }
 
-- (void)removeReactSubview:(id <RCTComponent>)subview {
+- (void)removeReactSubview:(UIView *)subview {
     [super removeReactSubview:subview];
     if ([subview isKindOfClass:[AMapMarker class]]) {
         AMapMarker *marker = (AMapMarker *) subview;
-        [self removeAnnotation:marker.annotation];
+        [self.mapView removeAnnotation:marker.annotation];
     }
     if ([subview isKindOfClass:[AMapOverlay class]]) {
-        [self removeOverlay:(id <MAOverlay>) subview];
+        [self.mapView removeOverlay:(id <MAOverlay>) subview];
     }
 }
 
 - (AMapMarker *)getMarker:(id <MAAnnotation>)annotation {
     return _markers[[@(annotation.hash) stringValue]];
+}
+
+- (void)setShowsScale:(BOOL)shows {
+    self.mapView.showsScale = shows;
+}
+
+- (void)setShowsIndoorMap:(BOOL)shows {
+    self.mapView.showsIndoorMap = shows;
+}
+
+- (void)setShowsLabels:(BOOL)shows {
+    self.mapView.showsLabels = shows;
+}
+
+
+- (void)setShowsBuildings:(BOOL)shows {
+    self.mapView.showsBuildings = shows;
+}
+
+- (void)setZoomLevel:(CGFloat)zoomLevel {
+    self.mapView.zoomLevel = zoomLevel;
+}
+
+- (void)setMinZoomLevel:(CGFloat)minZoomLevel {
+    self.mapView.minZoomLevel = minZoomLevel;
+}
+
+- (void)setMaxZoomLevel:(CGFloat)maxZoomLevel {
+    self.mapView.maxZoomLevel = maxZoomLevel;
+}
+
+- (void)setZoomEnabled:(BOOL)zoomEnabled {
+    self.mapView.zoomEnabled = zoomEnabled;
+}
+
+- (void)setScrollEnabled:(BOOL)scrollEnabled {
+    self.mapView.scrollEnabled = scrollEnabled;
+}
+
+- (void)setRotateEnabled:(BOOL)rotateEnabled {
+    self.mapView.rotateEnabled = rotateEnabled;
+}
+
+- (void)setMapType:(MAMapType)mapType {
+    self.mapView.mapType = mapType;
+}
+
+- (void)setLimitRegion:(MACoordinateRegion)limitRegion {
+    self.mapView.limitRegion = limitRegion;
+}
+
+- (void)setDistanceFilter:(CLLocationDistance)distanceFilter {
+    self.mapView.distanceFilter = distanceFilter;
+}
+
+- (void)mapView:(MAMapView *)mapView didSingleTappedAtCoordinate:(CLLocationCoordinate2D)coordinate {
+    if (self.onPress) {
+        self.onPress(@{
+                          @"latitude": @(coordinate.latitude),
+                          @"longitude": @(coordinate.longitude),
+                          });
+    }
+}
+
+- (void)mapView:(MAMapView *)mapView didLongPressedAtCoordinate:(CLLocationCoordinate2D)coordinate {
+    if (self.onLongPress) {
+        self.onLongPress(@{
+                              @"latitude": @(coordinate.latitude),
+                              @"longitude": @(coordinate.longitude),
+                              });
+    }
+}
+
+- (void)mapView:(MAMapView *)mapView didUpdateUserLocation:(MAUserLocation *)userLocation updatingLocation:(BOOL)updatingLocation {
+    if (self.onLocation) {
+        self.onLocation(@{
+                             @"latitude": @(userLocation.coordinate.latitude),
+                             @"longitude": @(userLocation.coordinate.longitude),
+                             @"accuracy": @((userLocation.location.horizontalAccuracy + userLocation.location.verticalAccuracy) / 2),
+                             @"altitude": @(userLocation.location.altitude),
+                             @"speed": @(userLocation.location.speed),
+                             @"timestamp": @(userLocation.location.timestamp.timeIntervalSince1970),
+                             });
+    }
+}
+
+- (MAAnnotationView *)mapView:(MAMapView *)mapView viewForAnnotation:(id <MAAnnotation>)annotation {
+    if ([annotation isKindOfClass:[MAPointAnnotation class]]) {
+        AMapMarker *marker = [self getMarker:annotation];
+        return marker.annotationView;
+    }
+    return nil;
+}
+
+- (MAOverlayRenderer *)mapView:(MAMapView *)mapView rendererForOverlay:(id <MAOverlay>)overlay {
+    if ([overlay isKindOfClass:[AMapOverlay class]]) {
+        return ((AMapOverlay *) overlay).renderer;
+    }
+    return nil;
+}
+
+- (void)mapView:(MAMapView *)mapView didSelectAnnotationView:(MAAnnotationView *)view {
+    AMapMarker *marker = [self getMarker:view.annotation];
+    if (marker.onPress) {
+        marker.onPress(nil);
+    }
+}
+
+- (void)mapView:(MAMapView *)mapView didAnnotationViewCalloutTapped:(MAAnnotationView *)view {
+    AMapMarker *marker = [self getMarker:view.annotation];
+    if (marker.onInfoWindowPress) {
+        marker.onInfoWindowPress(nil);
+    }
+}
+
+- (void)mapView:(MAMapView *)mapView annotationView:(MAAnnotationView *)view didChangeDragState:(MAAnnotationViewDragState)newState
+   fromOldState:(MAAnnotationViewDragState)oldState {
+    AMapMarker *marker = [self getMarker:view.annotation];
+    if (newState == MAAnnotationViewDragStateStarting && marker.onDragStart) {
+        marker.onDragStart(nil);
+    }
+    if (newState == MAAnnotationViewDragStateDragging) {
+        if (marker.onDrag) {
+            marker.onDrag(nil);
+        }
+    }
+    if (newState == MAAnnotationViewDragStateEnding && marker.onDragEnd) {
+        marker.onDragEnd(@{
+                           @"latitude": @(marker.annotation.coordinate.latitude),
+                           @"longitude": @(marker.annotation.coordinate.longitude),
+                           });
+    }
+}
+
+- (void)mapViewRegionChanged:(MAMapView *)mapView {
+    if (self.onStatusChange) {
+        MAMapStatus *status = mapView.getMapStatus;
+        self.onStatusChange(@{
+                                 @"zoomLevel": @(status.zoomLevel),
+                                 @"tilt": @(status.cameraDegree),
+                                 @"rotation": @(status.rotationDegree),
+                                 @"latitude": @(status.centerCoordinate.latitude),
+                                 @"longitude": @(status.centerCoordinate.longitude),
+                                 });
+    }
+}
+
+- (void)mapView:(MAMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
+    if (self.onStatusChangeComplete) {
+        MAMapStatus *status = mapView.getMapStatus;
+        self.onStatusChangeComplete(@{
+                                         @"zoomLevel": @(status.zoomLevel),
+                                         @"tilt": @(status.cameraDegree),
+                                         @"rotation": @(status.rotationDegree),
+                                         @"latitude": @(status.centerCoordinate.latitude),
+                                         @"longitude": @(status.centerCoordinate.longitude),
+                                         @"latitudeDelta": @(mapView.region.span.latitudeDelta),
+                                         @"longitudeDelta": @(mapView.region.span.longitudeDelta),
+                                         });
+    }
+}
+
+- (void)mapInitComplete:(MAMapView *)mapView {
+    self.loaded = YES;
+    
+    // struct 里的值会被初始化为 0，这里以此作为条件，判断 initialRegion 是否被设置过
+    // 但实际上经度为 0 是一个合法的坐标，只是考虑到高德地图只在中国使用，就这样吧
+    if (self.initialRegion.center.latitude != 0) {
+        mapView.region = self.initialRegion;
+    }
 }
 
 @end

--- a/lib/ios/AMap3D/maps/AMapViewManager.m
+++ b/lib/ios/AMap3D/maps/AMapViewManager.m
@@ -6,7 +6,7 @@
 #pragma ide diagnostic ignored "OCUnusedClassInspection"
 #pragma ide diagnostic ignored "-Woverriding-method-mismatch"
 
-@interface AMapViewManager : RCTViewManager <MAMapViewDelegate>
+@interface AMapViewManager : RCTViewManager
 @end
 
 @implementation AMapViewManager
@@ -15,9 +15,6 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view {
     AMapView *mapView = [AMapView new];
-    mapView.centerCoordinate = CLLocationCoordinate2DMake(39.9242, 116.3979);
-    mapView.zoomLevel = 10;
-    mapView.delegate = self;
     return mapView;
 }
 
@@ -52,7 +49,7 @@ RCT_EXPORT_VIEW_PROPERTY(onStatusChangeComplete, RCTBubblingEventBlock)
 
 RCT_EXPORT_METHOD(animateTo:(nonnull NSNumber *)reactTag params:(NSDictionary *)params duration:(NSInteger)duration) {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        AMapView *mapView = (AMapView *) viewRegistry[reactTag];
+        MAMapView *mapView = ((AMapView *) viewRegistry[reactTag]).mapView;
         MAMapStatus *mapStatus = mapView.getMapStatus;
         if (params[@"zoomLevel"]) {
             mapStatus.zoomLevel = [params[@"zoomLevel"] floatValue];
@@ -72,122 +69,4 @@ RCT_EXPORT_METHOD(animateTo:(nonnull NSNumber *)reactTag params:(NSDictionary *)
         [mapView setMapStatus:mapStatus animated:YES duration:duration / 1000.0];
     }];
 }
-
-- (void)mapView:(AMapView *)mapView didSingleTappedAtCoordinate:(CLLocationCoordinate2D)coordinate {
-    if (mapView.onPress) {
-        mapView.onPress(@{
-                @"latitude": @(coordinate.latitude),
-                @"longitude": @(coordinate.longitude),
-        });
-    }
-}
-
-- (void)mapView:(AMapView *)mapView didLongPressedAtCoordinate:(CLLocationCoordinate2D)coordinate {
-    if (mapView.onLongPress) {
-        mapView.onLongPress(@{
-                @"latitude": @(coordinate.latitude),
-                @"longitude": @(coordinate.longitude),
-        });
-    }
-}
-
-- (void)mapView:(AMapView *)mapView didUpdateUserLocation:(MAUserLocation *)userLocation updatingLocation:(BOOL)updatingLocation {
-    if (mapView.onLocation) {
-        mapView.onLocation(@{
-                @"latitude": @(userLocation.coordinate.latitude),
-                @"longitude": @(userLocation.coordinate.longitude),
-                @"accuracy": @((userLocation.location.horizontalAccuracy + userLocation.location.verticalAccuracy) / 2),
-                @"altitude": @(userLocation.location.altitude),
-                @"speed": @(userLocation.location.speed),
-                @"timestamp": @(userLocation.location.timestamp.timeIntervalSince1970),
-        });
-    }
-}
-
-- (MAAnnotationView *)mapView:(AMapView *)mapView viewForAnnotation:(id <MAAnnotation>)annotation {
-    if ([annotation isKindOfClass:[MAPointAnnotation class]]) {
-        AMapMarker *marker = [mapView getMarker:annotation];
-        return marker.annotationView;
-    }
-    return nil;
-}
-
-- (MAOverlayRenderer *)mapView:(MAMapView *)mapView rendererForOverlay:(id <MAOverlay>)overlay {
-    if ([overlay isKindOfClass:[AMapOverlay class]]) {
-        return ((AMapOverlay *) overlay).renderer;
-    }
-    return nil;
-}
-
-- (void)mapView:(AMapView *)mapView didSelectAnnotationView:(MAAnnotationView *)view {
-    AMapMarker *marker = [mapView getMarker:view.annotation];
-    if (marker.onPress) {
-        marker.onPress(nil);
-    }
-}
-
-- (void)mapView:(AMapView *)mapView didAnnotationViewCalloutTapped:(MAAnnotationView *)view {
-    AMapMarker *marker = [mapView getMarker:view.annotation];
-    if (marker.onInfoWindowPress) {
-        marker.onInfoWindowPress(nil);
-    }
-}
-
-- (void)mapView:(AMapView *)mapView annotationView:(MAAnnotationView *)view didChangeDragState:(MAAnnotationViewDragState)newState
-   fromOldState:(MAAnnotationViewDragState)oldState {
-    AMapMarker *marker = [mapView getMarker:view.annotation];
-    if (newState == MAAnnotationViewDragStateStarting && marker.onDragStart) {
-        marker.onDragStart(nil);
-    }
-    if (newState == MAAnnotationViewDragStateDragging) {
-        if (marker.onDrag) {
-            marker.onDrag(nil);
-        }
-    }
-    if (newState == MAAnnotationViewDragStateEnding && marker.onDragEnd) {
-        marker.onDragEnd(@{
-                @"latitude": @(marker.annotation.coordinate.latitude),
-                @"longitude": @(marker.annotation.coordinate.longitude),
-        });
-    }
-}
-
-- (void)mapViewRegionChanged:(AMapView *)mapView {
-    if (mapView.onStatusChange) {
-        MAMapStatus *status = mapView.getMapStatus;
-        mapView.onStatusChange(@{
-                @"zoomLevel": @(status.zoomLevel),
-                @"tilt": @(status.cameraDegree),
-                @"rotation": @(status.rotationDegree),
-                @"latitude": @(status.centerCoordinate.latitude),
-                @"longitude": @(status.centerCoordinate.longitude),
-        });
-    }
-}
-
-- (void)mapView:(AMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
-    if (mapView.onStatusChangeComplete) {
-        MAMapStatus *status = mapView.getMapStatus;
-        mapView.onStatusChangeComplete(@{
-                @"zoomLevel": @(status.zoomLevel),
-                @"tilt": @(status.cameraDegree),
-                @"rotation": @(status.rotationDegree),
-                @"latitude": @(status.centerCoordinate.latitude),
-                @"longitude": @(status.centerCoordinate.longitude),
-                @"latitudeDelta": @(mapView.region.span.latitudeDelta),
-                @"longitudeDelta": @(mapView.region.span.longitudeDelta),
-        });
-    }
-}
-
-- (void)mapInitComplete:(AMapView *)mapView {
-    mapView.loaded = YES;
-
-    // struct 里的值会被初始化为 0，这里以此作为条件，判断 initialRegion 是否被设置过
-    // 但实际上经度为 0 是一个合法的坐标，只是考虑到高德地图只在中国使用，就这样吧
-    if (mapView.initialRegion.center.latitude != 0) {
-        mapView.region = mapView.initialRegion;
-    }
-}
-
 @end

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
     "flow-bin": "^0.69.0",
-    "react": "16.2.0",
-    "react-native": "0.52.3",
-    "react-navigation": "^1.5.11"
+    "react": "16.6.1",
+    "react-native": "0.57.7",
+    "react-navigation": "^2.18.0"
   },
   "presets": [
     "react-native"


### PR DESCRIPTION
相关 issue #251 #428 #435 
大概原因是 RN 会使用 setBounds 设置控件宽高 https://github.com/facebook/react-native/blob/master/React/Views/UIView+React.m#L200
然后高德地图的 setBounds 可能被重写过了导致在动画过程中创建的 MapView 宽高会随机超出
解决方法是给 MapView 包一层 UIView 就好了

具体深入的原因我也不是很清楚，因为我是开发 Android 的...