### PR TITLE
Fix：iOS上地图中心点经常不能对准的问题。

### DIFF
--- a/lib/ios/AMap3D/maps/AMapView.m
+++ b/lib/ios/AMap3D/maps/AMapView.m
@@ -9,12 +9,25 @@
 @implementation AMapView {
     NSMutableDictionary *_markers;
     MAUserLocationRepresentation *_locationStyle;
+    BOOL _isBoundsInit;
 }
 
 - (instancetype)init {
+    _isBoundsInit = NO;
     _markers = [NSMutableDictionary new];
     self = [super init];
     return self;
+}
+
+- (void)setFrame:(CGRect)frame {
+    if (!_isBoundsInit) {
+        [super setFrame:frame];
+    }
+}
+
+- (void)setBounds:(CGRect)bounds {
+    _isBoundsInit = YES;
+    [super setBounds:bounds];
 }
 
 - (void)setShowsTraffic:(BOOL)shows {


### PR DESCRIPTION
我用的是RN 0.57.2，在iOS上，只是最简单的渲染MapView，多次重复进入，有的时候显示正确，有的时候会有很大的偏移。

看了下Issue，提到的实际在iOS上的frame发生了变化，我在AMapView.m中拦截了`setFrame`和`setBounds`，结果如下：

* `setFrame`：一般调用两次。一次是`AMapViewManager.m`中的`view`方法，调用`new`初始化时，传入的`frame`为`(0, 0, 0, 0)`，记为A。另一次是`frame`为屏幕宽高的两倍，记为B。
* `setBounds`：调用一次，是RN部分设置的实际宽高，记为C。

可以知道：`setFrame`设置的长宽有问题，`setBounds`设置的是正确的。

A是第一次调用，而B和C的调用顺序不确定。有时候B先执行，则结果正确；有时候C先执行，则结果异常。**个人猜测**是两个线程同时设置导致的，B是高德SDK自动适配的设置线程，C是RN的处理线程。

于是我在`setBounds`中加上标识，一旦其被调用过，则`setFrame`就无法调用了。这样可以保证A是始终生效的，C如果调用过，则B无法生效。经测试，解决了问题，并且通过`setState`动态改变视图位置和宽高依旧有效。

相关Issue：#218 #251 #419 #435 