### PR TITLE
Fix the overflow of long to int

### DIFF
--- a/lib/android/src/main/java/cn/qiuxiang/react/amap3d/maps/AMapView.kt
+++ b/lib/android/src/main/java/cn/qiuxiang/react/amap3d/maps/AMapView.kt
@@ -51,7 +51,7 @@ class AMapView(context: Context) : TextureMapView(context) {
             event.putDouble("accuracy", location.accuracy.toDouble())
             event.putDouble("altitude", location.altitude)
             event.putDouble("speed", location.speed.toDouble())
-            event.putInt("timestamp", location.time.toInt())
+            event.putDouble("timestamp", location.time.toDouble())
             emit(id, "onLocation", event)
         }
 


### PR DESCRIPTION
location.time is long, it will overflow when convert to int.