### PR TITLE
Support gradle 6

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -2,9 +2,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 buildscript {
-    ext.kotlin_version = '1.3.10'
+    ext.kotlin_version = '1.3.50'
 
     repositories {
+        google()
         jcenter()
     }
 
@@ -24,7 +25,7 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.amap.api:3dmap:6.6.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.amap.api:3dmap:6.6.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }


### PR DESCRIPTION
Gradle 6 now requiring the Kotlin plugin to be version 1.3.50 or higher.
https://docs.gradle.org/6.0-rc-3/userguide/upgrading_version_5.html#kotlin_dsl_ide_support_now_requires_kotlin_intellij_plugin_1_3_50