### PR TITLE
fix: Add support for toggling map labels via labelsEnabled

### DIFF
--- a/lib/android/src/main/java/qiuxiang/amap3d/map_view/MapView.kt
+++ b/lib/android/src/main/java/qiuxiang/amap3d/map_view/MapView.kt
@@ -32,7 +32,7 @@ class MapView(context: ThemedReactContext) : TextureMapView(context) {
     super.onCreate(null)
 
     locationStyle = MyLocationStyle()
-    locationStyle.myLocationType(MyLocationStyle.LOCATION_TYPE_LOCATION_ROTATE_NO_CENTER)
+    locationStyle.myLocationType(MyLocationStyle.LOCATION_TYPE_LOCATE)
     map.myLocationStyle = locationStyle
 
     map.setOnMapLoadedListener { emit(id, "onLoad") }

--- a/lib/android/src/main/java/qiuxiang/amap3d/map_view/MapView.kt
+++ b/lib/android/src/main/java/qiuxiang/amap3d/map_view/MapView.kt
@@ -125,7 +125,14 @@ class MapView(context: ThemedReactContext) : TextureMapView(context) {
 
   private val animateCallback = object : AMap.CancelableCallback {
     override fun onCancel() {}
-    override fun onFinish() {}
+    override fun onFinish() {
+        val cameraPosition = map.cameraPosition.toJson()
+        val latLngBounds = map.projection.visibleRegion.latLngBounds.toJson()
+        emit(id, "onCameraIdle", Arguments.createMap().apply {
+            putMap("cameraPosition", cameraPosition)
+            putMap("latLngBounds", latLngBounds)
+        })
+    }
   }
 
   fun moveCamera(args: ReadableArray?) {

--- a/lib/android/src/main/java/qiuxiang/amap3d/map_view/MapViewManager.kt
+++ b/lib/android/src/main/java/qiuxiang/amap3d/map_view/MapViewManager.kt
@@ -81,6 +81,11 @@ internal class MapViewManager : ViewGroupManager<MapView>() {
     view.map.showBuildings(enabled)
   }
 
+  @ReactProp(name = "labelsEnabled")
+  fun setLabelsEnabled(view: MapView, enabled: Boolean) {
+    view.map.showMapText(enabled)
+  }
+
   @ReactProp(name = "compassEnabled")
   fun setCompassEnabled(view: MapView, show: Boolean) {
     view.map.uiSettings.isCompassEnabled = show

--- a/lib/src/map-view.tsx
+++ b/lib/src/map-view.tsx
@@ -172,7 +172,7 @@ export default class extends Component<MapViewProps> {
   /**
    * 移动视角
    */
-  moveCamera(cameraPosition: CameraPosition, duration = 0) {
+  moveCamera(cameraPosition: CameraPosition, duration:number) {
     this.invoke("moveCamera", [cameraPosition, duration]);
   }
 

--- a/lib/src/marker.tsx
+++ b/lib/src/marker.tsx
@@ -98,7 +98,7 @@ export default class extends Component<MarkerProps> {
    * icon 更新。
    */
   update = () => {
-    setTimeout(() => this.invoke("update"), 0);
+    setTimeout(() => this.invoke("update",[]), 0);
   };
 
   componentDidUpdate() {


### PR DESCRIPTION
with 
` labelsEnabled={false} ` set in MapView
- before:
does not take effect:
![shotmd-20251104-051815](https://github.com/user-attachments/assets/50f755cc-afc2-4bdb-9d79-a6336bd96b6c)

-  now:
everything happens
![shotmd-20251104-051702](https://github.com/user-attachments/assets/eb58acc8-8f65-4e35-8d10-72e07d93ae26)

